### PR TITLE
initial commit of allow_hanging_commas feature

### DIFF
--- a/lkml/__init__.py
+++ b/lkml/__init__.py
@@ -7,11 +7,12 @@ from lkml.lexer import Lexer
 from lkml.parser import Parser
 
 
-def load(file_object):
+def load(file_object, allow_hanging_commas=False):
     text = file_object.read()
     lexer = Lexer(text)
     tokens = lexer.scan()
     parser = Parser(tokens)
+    parser.set_allow_hanging_commas(allow_hanging_commas)
     result = parser.parse()
     return result
 
@@ -36,6 +37,12 @@ def parse_args(args):
         default=logging.WARN,
         help="increase logging verbosity",
     )
+    parser.add_argument(
+        "--allow_hanging_commas",
+        dest="allow_hanging_commas",
+        default=False,
+        help="allow_hanging_commas",
+    )
 
     return parser.parse_args(args)
 
@@ -56,7 +63,11 @@ def cli():
 
     logging.getLogger().setLevel(args.log_level)
 
-    lookml = load(args.file)
+    allow_hanging_commas = False
+    if args.allow_hanging_commas is not None:
+        allow_hanging_commas = args.allow_hanging_commas
+
+    lookml = load(args.file, allow_hanging_commas)
     args.file.close()
 
     json_string = json.dumps(lookml, indent=2)

--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -45,6 +45,11 @@ class Parser:
         self.logger = logging.getLogger(__name__)
         self.depth = -1
         self.log_debug = self.logger.isEnabledFor(logging.DEBUG)
+        self.allow_hanging_commas = False
+
+    def set_allow_hanging_commas(self, setting):
+        assert type(setting) is bool
+        self.allow_hanging_commas = setting
 
     def jump_to_index(self, index: int):
         self.index = index
@@ -321,6 +326,7 @@ class Parser:
             return None
 
         while not self.check(tokens.ListEndToken):
+
             if self.check(tokens.CommaToken):
                 self.advance()
             else:
@@ -331,6 +337,8 @@ class Parser:
             elif self.check(tokens.QuotedLiteralToken):
                 values.append(self.consume_token_value())
             else:
+                if self.allow_hanging_commas and self.check(tokens.ListEndToken):
+                    break
                 return None
 
         if self.log_debug:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -352,8 +352,8 @@ def test_parse_list_with_literals():
         ]
     }
 
-
 def test_parse_list_with_trailing_comma():
+    # list with trailing comma and allow_trailing_comma=False
     stream = (
         tokens.LiteralToken("drill_fields", 1),
         tokens.ValueToken(1),
@@ -367,6 +367,42 @@ def test_parse_list_with_trailing_comma():
     result = parser.parse_list()
     assert result is None
 
+def test_parse_list_with_trailing_comma2():
+    # list with trailing comma and allow_trailing_comma=True
+    stream = (
+        tokens.LiteralToken("drill_fields", 1),
+        tokens.ValueToken(1),
+        tokens.ListStartToken(1),
+        tokens.LiteralToken("view_name.field_one", 1),
+        tokens.CommaToken(1),
+        tokens.ListEndToken(1),
+        tokens.StreamEndToken(1),
+    )
+    parser = lkml.parser.Parser(stream)
+    parser.set_allow_hanging_commas(True)
+    result = parser.parse_list()
+    assert result == {
+        "drill_fields": [
+            "view_name.field_one"
+        ]
+    }
+
+def test_parse_list_with_trailing_comma3():
+    # list with double comma
+    stream = (
+        tokens.LiteralToken("drill_fields", 1),
+        tokens.ValueToken(1),
+        tokens.ListStartToken(1),
+        tokens.LiteralToken("view_name.field_one", 1),
+        tokens.CommaToken(1),
+        tokens.CommaToken(1),
+        tokens.ListEndToken(1),
+        tokens.StreamEndToken(1),
+    )
+    parser = lkml.parser.Parser(stream)
+    parser.set_allow_hanging_commas(True)
+    result = parser.parse_list()
+    assert result is None
 
 def test_parse_list_with_missing_comma():
     stream = (


### PR DESCRIPTION
Looker allows hanging commas in lists in LookML. lkml's Parser however, is very strict. This PR sets a flag to allow it to be more forgiving: default is strict, flag allows final trailing comma in a list