### PR TITLE
initial commit

### DIFF
--- a/lkml/__init__.py
+++ b/lkml/__init__.py
@@ -7,11 +7,12 @@ from lkml.lexer import Lexer
 from lkml.parser import Parser
 
 
-def load(file_object):
+def load(file_object, allow_dupe_model_keys=False):
     text = file_object.read()
     lexer = Lexer(text)
     tokens = lexer.scan()
     parser = Parser(tokens)
+    parser.set_allow_dupe_model_keys(allow_dupe_model_keys)
     result = parser.parse()
     return result
 
@@ -36,6 +37,12 @@ def parse_args(args):
         default=logging.WARN,
         help="increase logging verbosity",
     )
+    parser.add_argument(
+        "--dupe_model_keys",
+        dest="dupe_model_keys",
+        default=False,
+        help="allow dupe model keys",
+    )
 
     return parser.parse_args(args)
 
@@ -56,7 +63,11 @@ def cli():
 
     logging.getLogger().setLevel(args.log_level)
 
-    lookml = load(args.file)
+    allow_dupe_model_keys = False
+    if args.allow_dupe_model_keys is not None:
+        allow_dupe_model_keys = args.dupe_model_keys
+
+    lookml = load(args.file, allow_dupe_model_keys)
     args.file.close()
 
     json_string = json.dumps(lookml, indent=2)

--- a/tests/resources/model_with_dupe_field.model.lkml
+++ b/tests/resources/model_with_dupe_field.model.lkml
@@ -1,0 +1,124 @@
+label: "desired label name"
+connection: "connection_name"
+include: "filename_or_pattern"
+include: "filename_or_pattern"
+
+fiscal_month_offset: N
+persist_for: "N seconds"
+persist_with: datagroup_name
+case_sensitive: yes
+week_start_day: monday
+week_start_day: tuesday
+
+named_value_format: desired_format_name {
+  value_format: "excel-style formatting string"
+}
+
+named_value_format: desired_format_name {
+  value_format: "excel-style formatting string"
+}
+
+map_layer: identifier {
+  extents_json_url: "URL to JSON extents file"
+  feature_key: "Name of TopoJSON object"
+  file: "TopoJSON file name" # or use the url subparameter
+  format: topojson
+  label: "Label I want"
+  max_zoom_level: 10
+  min_zoom_level: 5
+  projection: geo_projection
+  property_key: "TopoJSON property"
+  property_label_key: "Label for TopoJSON property"
+  url: "URL that contains map file" # or use the file subparameter
+}
+
+datagroup: datagroup_name {
+  sql_trigger: SQL query ;;
+  max_cache_age: "N minutes"
+}
+
+datagroup: datagroup_name {
+  sql_trigger: SQL query ;;
+  max_cache_age: "N minutes"
+}
+
+access_grant: access_grant_name {
+  user_attribute: user_attribute_name
+  allowed_values: ["value_1", "value_2"]
+}
+
+access_grant: access_grant_name {
+  user_attribute: user_attribute_name
+  allowed_values: ["value_1", "value_2"]
+}
+
+explore: view_name {
+  description: "description string"
+  label: "desired label name"
+  group_label: "label to use as a heading in the Explore menu"
+  view_label: "field picker heading to use for the Explore's fields"
+  extends: [explore_name, explore_name]
+  extension: required
+  symmetric_aggregates: yes
+  hidden: yes
+  fields: [field_or_set, field_or_set]
+
+  sql_always_where: SQL WHERE condition ;;
+  required_access_grants: [access_grant_name, access_grant_name]
+
+  always_filter: {
+    filters: {
+      field: field_name
+      value: "looker filter expression"
+    }
+  }
+
+  conditionally_filter: {
+    filters: {
+      field: field_name
+      value: "looker filter expression"
+    }
+    unless: [field_or_set, field_or_set]
+  }
+
+  access_filter: {
+    field: fully_scoped_field
+    user_attribute: user_attribute_name
+  }
+
+  always_join: [view_name, view_name]
+
+  join: view_name {
+    type: left_outer
+    relationship: one_to_one
+    from: view_name
+    sql_table_name: table_name ;;
+    view_label: "desired label name"
+    fields: [field_or_set, field_or_set]
+    required_joins: [view_name, view_name]
+    foreign_key: dimension_name
+    sql_on: SQL ON clause ;;
+    required_access_grants: [access_grant_name, access_grant_name]
+  }
+
+  join: view_name {
+    type: left_outer
+    relationship: one_to_one
+    from: view_name
+    sql_table_name: table_name ;;
+    view_label: "desired label name"
+    fields: [field_or_set, field_or_set]
+    required_joins: [view_name, view_name]
+    foreign_key: dimension_name
+    sql_on: SQL ON clause ;;
+    required_access_grants: [access_grant_name, access_grant_name]
+  }
+
+  persist_for: "N hours"
+  persist_with: datagroup_name
+  from: view_name
+  view_name: view_name
+  case_sensitive: true
+  sql_table_name: table_name ;;
+  cancel_grouping_fields: [fully_scoped_field, fully_scoped_field]
+}

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,12 +1,13 @@
+import pytest
 from pathlib import Path
 import lkml
 
 
-def load(filename):
+def load(filename,  allow_dupe_model_keys=False):
     """Helper method to load a LookML file from tests/resources and parse it."""
     path = Path(__file__).parent / "resources" / filename
     with path.open() as file:
-        return lkml.load(file)
+        return lkml.load(file, allow_dupe_model_keys)
 
 
 def test_block_with_single_quoted_field():
@@ -30,5 +31,14 @@ def test_view_with_all_fields():
 
 
 def test_model_with_all_fields():
-    lookml = load("model_with_all_fields.model.lkml")
-    assert lookml is not None
+   lookml = load("model_with_all_fields.model.lkml")
+   assert lookml is not None
+
+
+def test_model_with_dupe_fields():
+   with pytest.raises(Exception) as e:
+       lookml = load("model_with_dupe_field.model.lkml")
+   assert 'Key "week_start_day" already exists in tree and would overwrite the existing value' in str(e.value)
+
+def test_model_with_dupe_fields2():
+   lookml = load("model_with_dupe_field.model.lkml", allow_dupe_model_keys=True)


### PR DESCRIPTION
LookML allow (some) duplicate key in models. For instance, this is valid LookML:
```
connection: "prod-data-playground-std-bq"
connection: "prod-data-playground-std-bq"
label: "CIE - Memberhip Facts"
label: "CIE - Memberhip Facts"
week_start_day: sunday
week_start_day: sunday
include: "*.view.lkml"                       # include all views in this project
include: "*.view.lkml"                       # include all views in this project
include: "attendance_base.explore.lkml"
include: "attendance_base.explore.lkml"
```
it just takes the last value per key.

If lkml encounters a dupe key, it throws exception such as `KeyError: 'Key "week_start_day" already exists in tree and would overwrite the existing value.'`

This PR provides a flag whereby someone can specify that duplicate model keys is OK, and to take the last value