### PR TITLE
0.1.1

### DIFF
--- a/lkml/__init__.py
+++ b/lkml/__init__.py
@@ -47,7 +47,7 @@ def cli():
     handler = logging.StreamHandler()
     handler.setLevel(logging.DEBUG)
 
-    formatter = logging.Formatter("%(name)s . %(message)s")
+    formatter = logging.Formatter("%(name)s %(levelname)s: %(message)s")
 
     handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -14,7 +14,7 @@ pair = key value
 
 list = key "[" csv? "]"
 
-csv = (literal / quoted_literal) ("," (literal / quoted_literal))*
+csv = (literal / quoted_literal) ("," (literal / quoted_literal))* ","?
 
 value = literal / quoted_literal / expression_block
 
@@ -307,9 +307,7 @@ class Parser:
     @backtrack_if_none
     def parse_csv(self) -> Optional[list]:
         if self.log_debug:
-            grammar = (
-                "[csv] = (literal / quoted_literal) (" " (literal / quoted_literal))*"
-            )
+            grammar = '[csv] = (literal / quoted_literal) ("," (literal / quoted_literal))* ","?'
             self.logger.debug("%sTry to parse %s", self.depth * DELIMITER, grammar)
         values = []
 
@@ -330,6 +328,8 @@ class Parser:
                 values.append(self.consume_token_value())
             elif self.check(tokens.QuotedLiteralToken):
                 values.append(self.consume_token_value())
+            elif self.check(tokens.ListEndToken):
+                break
             else:
                 return None
 

--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -166,7 +166,7 @@ class Parser:
             token = self.tokens[self.progress]
             raise SyntaxError(
                 f"Unable to find a matching expression for '{token.id}' "
-                f"on line {token.line_number}, position "
+                f"on line {token.line_number}"
             )
 
         if self.log_debug:

--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -125,6 +125,7 @@ class Parser:
             "join",
             "datagroup",
             "access_grant",
+            "sql_step",
         ]:
             plural_key = key.rstrip("s") + "s"
             if plural_key in target.keys():

--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -126,6 +126,7 @@ class Parser:
             "datagroup",
             "access_grant",
             "sql_step",
+            "sql_where",
         ]:
             plural_key = key.rstrip("s") + "s"
             if plural_key in target.keys():

--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -145,7 +145,7 @@ class Parser:
     def parse_expression(self) -> dict:
         if self.log_debug:
             grammar = "[expression] = (block / pair / list)*"
-            self.logger.debug(self.depth * DELIMITER + f"Try to parse {grammar}")
+            self.logger.debug("%sTry to parse %s", self.depth * DELIMITER, grammar)
         expression: dict = {}
         if self.check(tokens.StreamStartToken):
             self.advance()

--- a/lkml/tokens.py
+++ b/lkml/tokens.py
@@ -10,7 +10,7 @@ class Token:
 
     def __repr__(self):
         value = getattr(self, "value", "").strip()
-        value = (value[:25].rstrip() + " ...") if len(value) > 25 else value
+        value = (value[:25].rstrip() + " ... ") if len(value) > 25 else value
         return f"{self.__class__.__name__}({value})"
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Topic :: Software Development",
     ],
-    keywords="",
+    keywords="lookml looker parser",
     entry_points={"console_scripts": ["lkml = lkml.__init__:cli"]},
     packages=find_packages(exclude=["docs", "tests*", "scripts"]),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/joshtemple/lkml",
     download_url="https://github.com/joshtemple/lkml/tarball/" + __version__,
-    license="BSD",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from setuptools import setup, find_packages
 from codecs import open
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 here = Path(__file__).parent.resolve()
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     keywords="",
     entry_points={"console_scripts": ["lkml = lkml.__init__:cli"]},
-    packages=find_packages(exclude=["docs", "tests*"]),
+    packages=find_packages(exclude=["docs", "tests*", "scripts"]),
     include_package_data=True,
     author="Josh Temple",
     tests_require=["pytest"],

--- a/tests/resources/duplicate_non_top_level_keys.view.lkml
+++ b/tests/resources/duplicate_non_top_level_keys.view.lkml
@@ -1,0 +1,4 @@
+view: view_name {
+  label: "View Label"
+  label: "Another View Label"
+}

--- a/tests/resources/duplicate_top_level_keys.view.lkml
+++ b/tests/resources/duplicate_top_level_keys.view.lkml
@@ -1,0 +1,10 @@
+connection: "prod-data-playground-std-bq"
+connection: "prod-data-playground-std-bq"
+label: "CIE - Memberhip Facts"
+label: "CIE - Memberhip Facts"
+week_start_day: sunday
+week_start_day: sunday
+include: "*.view.lkml"                       # include all views in this project
+include: "*.view.lkml"                       # include all views in this project
+include: "attendance_base.explore.lkml"
+include: "attendance_base.explore.lkml"

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import pytest
 import lkml
 
 
@@ -34,6 +35,11 @@ def test_model_with_all_fields():
     assert lookml is not None
 
 
-def test_model_with_all_fields():
+def test_duplicate_top_level_keys():
     lookml = load("duplicate_top_level_keys.view.lkml")
     assert lookml is not None
+
+
+def test_duplicate_non_top_level_keys():
+    with pytest.raises(KeyError):
+        lookml = load("duplicate_non_top_level_keys.view.lkml")

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -32,3 +32,8 @@ def test_view_with_all_fields():
 def test_model_with_all_fields():
     lookml = load("model_with_all_fields.model.lkml")
     assert lookml is not None
+
+
+def test_model_with_all_fields():
+    lookml = load("duplicate_top_level_keys.view.lkml")
+    assert lookml is not None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -365,7 +365,7 @@ def test_parse_list_with_trailing_comma():
     )
     parser = lkml.parser.Parser(stream)
     result = parser.parse_list()
-    assert result is None
+    assert result == {"drill_fields": ["view_name.field_one"]}
 
 
 def test_parse_list_with_missing_comma():
@@ -405,6 +405,40 @@ def test_parse_list_with_no_opening_bracket():
         tokens.LiteralToken("view_name.field_one", 1),
         tokens.CommaToken(1),
         tokens.LiteralToken("view_name.field_two", 1),
+        tokens.StreamEndToken(1),
+    )
+    parser = lkml.parser.Parser(stream)
+    result = parser.parse_list()
+    assert result is None
+
+
+def test_parse_list_with_bad_token():
+    stream = (
+        tokens.LiteralToken("drill_fields", 1),
+        tokens.ValueToken(1),
+        tokens.ListStartToken(1),
+        tokens.LiteralToken("view_name.field_one", 1),
+        tokens.CommaToken(1),
+        tokens.LiteralToken("view_name.field_two", 1),
+        tokens.CommaToken(1),
+        tokens.ValueToken(1),
+        tokens.ListEndToken(1),
+        tokens.StreamEndToken(1),
+    )
+    parser = lkml.parser.Parser(stream)
+    result = parser.parse_list()
+    assert result is None
+
+
+def test_parse_list_with_only_commas():
+    stream = (
+        tokens.LiteralToken("drill_fields", 1),
+        tokens.ValueToken(1),
+        tokens.ListStartToken(1),
+        tokens.CommaToken(1),
+        tokens.CommaToken(1),
+        tokens.CommaToken(1),
+        tokens.ListEndToken(1),
         tokens.StreamEndToken(1),
     )
     parser = lkml.parser.Parser(stream)


### PR DESCRIPTION
- Allows hanging commas in lists (closes #5)
- Allows duplicate top-level keys but warns that they will be overwritten (closes #6)
- Logging shows the log level to differentiate between `DEBUG` and `WARNING` messages
- Remove portion of `SyntaxError` message which points to a non-existent line position
- Collapses multiple `sql_step` and `sql_where` keys into plural keys
- Some metadata fixes to `setup.py`