### PR TITLE
Standardize set formatting

### DIFF
--- a/lkml/serializer.py
+++ b/lkml/serializer.py
@@ -113,20 +113,14 @@ class Serializer:
         yield "["
 
         if values:
-            if len(values) > 5:
-                self.increase_level()
-                yield self.newline_indent
-                for i, value in enumerate(values):
-                    if i > 0:
-                        yield f",{self.newline_indent}"
-                    yield from self.write_value(key, value, force_quote)
-                self.decrease_level()
-                yield self.newline_indent
-            else:
-                for i, value in enumerate(values):
-                    if i > 0:
-                        yield f", "
-                    yield from self.write_value(key, value, force_quote)
+            self.increase_level()
+            yield self.newline_indent
+            for i, value in enumerate(values):
+                if i > 0:
+                    yield f",{self.newline_indent}"
+                yield from self.write_value(key, value, force_quote)
+            self.decrease_level()
+            yield self.newline_indent
         yield "]"
 
     def write_pair(self, key: str, value: str) -> Iterator[str]:

--- a/tests/resources/model_with_all_fields.model.lkml
+++ b/tests/resources/model_with_all_fields.model.lkml
@@ -43,12 +43,18 @@ datagroup: datagroup_name {
 
 access_grant: access_grant_name {
   user_attribute: user_attribute_name
-  allowed_values: ["value_1", "value_2"]
+  allowed_values: [
+    "value_1",
+    "value_2"
+  ]
 }
 
 access_grant: access_grant_name {
   user_attribute: user_attribute_name
-  allowed_values: ["value_1", "value_2"]
+  allowed_values: [
+    "value_1",
+    "value_2"
+  ]
 }
 
 explore: view_name {
@@ -56,14 +62,23 @@ explore: view_name {
   label: "desired label name"
   group_label: "label to use as a heading in the Explore menu"
   view_label: "field picker heading to use for the Explore's fields"
-  extends: [explore_name, explore_name]
+  extends: [
+    explore_name,
+    explore_name
+  ]
   extension: required
   symmetric_aggregates: yes
   hidden: yes
-  fields: [field_or_set, field_or_set]
+  fields: [
+    field_or_set,
+    field_or_set
+  ]
 
   sql_always_where: SQL WHERE condition ;;
-  required_access_grants: [access_grant_name, access_grant_name]
+  required_access_grants: [
+    access_grant_name,
+    access_grant_name
+  ]
 
   always_filter: {
     filters: {
@@ -77,7 +92,10 @@ explore: view_name {
       field: field_name
       value: "looker filter expression"
     }
-    unless: [field_or_set, field_or_set]
+    unless: [
+      field_or_set,
+      field_or_set
+    ]
   }
 
   access_filter: {
@@ -85,7 +103,10 @@ explore: view_name {
     user_attribute: user_attribute_name
   }
 
-  always_join: [view_name, view_name]
+  always_join: [
+    view_name,
+    view_name
+  ]
 
   join: view_name {
     type: left_outer
@@ -93,11 +114,20 @@ explore: view_name {
     from: view_name
     sql_table_name: table_name ;;
     view_label: "desired label name"
-    fields: [field_or_set, field_or_set]
-    required_joins: [view_name, view_name]
+    fields: [
+      field_or_set,
+      field_or_set
+    ]
+    required_joins: [
+      view_name,
+      view_name
+    ]
     foreign_key: dimension_name
     sql_on: SQL ON clause ;;
-    required_access_grants: [access_grant_name, access_grant_name]
+    required_access_grants: [
+      access_grant_name,
+      access_grant_name
+    ]
   }
 
   join: view_name {
@@ -106,11 +136,20 @@ explore: view_name {
     from: view_name
     sql_table_name: table_name ;;
     view_label: "desired label name"
-    fields: [field_or_set, field_or_set]
-    required_joins: [view_name, view_name]
+    fields: [
+      field_or_set,
+      field_or_set
+    ]
+    required_joins: [
+      view_name,
+      view_name
+    ]
     foreign_key: dimension_name
     sql_on: SQL ON clause ;;
-    required_access_grants: [access_grant_name, access_grant_name]
+    required_access_grants: [
+      access_grant_name,
+      access_grant_name
+    ]
   }
 
   persist_for: "N hours"
@@ -119,5 +158,8 @@ explore: view_name {
   view_name: view_name
   case_sensitive: true
   sql_table_name: table_name ;;
-  cancel_grouping_fields: [fully_scoped_field, fully_scoped_field]
+  cancel_grouping_fields: [
+    fully_scoped_field,
+    fully_scoped_field
+  ]
 }

--- a/tests/resources/view_with_all_fields.view.lkml
+++ b/tests/resources/view_with_all_fields.view.lkml
@@ -1,9 +1,15 @@
 view: view_name {
   sql_table_name: table_name ;;
   suggestions: no
-  extends: [view_name, view_name]
+  extends: [
+    view_name,
+    view_name
+  ]
   extension: required
-  required_access_grants: [access_grant_name, access_grant_name]
+  required_access_grants: [
+    access_grant_name,
+    access_grant_name
+  ]
   derived_table: {
     explore_source: explore_name {
       bind_filters: {
@@ -41,20 +47,35 @@ view: view_name {
     sql: SQL query ;;
     persist_for: "N hours"
     sql_trigger_value: SQL query ;;
-    cluster_keys: ["column_name", "column_name"]
+    cluster_keys: [
+      "column_name",
+      "column_name"
+    ]
     datagroup_trigger: datagroup_name
     distribution: "column_name"
     distribution_style: all
-    sortkeys: ["column_name", "column_name"]
-    indexes: ["column_name", "column_name"]
-    partition_keys: ["column_name", "column_name"]
+    sortkeys: [
+      "column_name",
+      "column_name"
+    ]
+    indexes: [
+      "column_name",
+      "column_name"
+    ]
+    partition_keys: [
+      "column_name",
+      "column_name"
+    ]
     create_process: {
       sql_step: SQL query ;;
     }
     sql_create: SQL query ;;
   }
   set: set_name {
-    fields: [field_or_set, field_or_set]
+    fields: [
+      field_or_set,
+      field_or_set
+    ]
   }
   dimension: field_name {
     action: {
@@ -137,16 +158,28 @@ view: view_name {
     group_item_label: "label to use for the field under its group label in the field picker"
     description: "description string"
     hidden: no
-    alias: [old_field_name, old_field_name]
+    alias: [
+      old_field_name,
+      old_field_name
+    ]
     value_format: "excel-style formatting string"
     value_format_name: format_name
     html: HTML expression using Liquid template elements ;;
     sql: SQL expression to generate the field value ;;
-    required_fields: [field_name, field_name]
-    drill_fields: [field_or_set, field_or_set]
+    required_fields: [
+      field_name,
+      field_name
+    ]
+    drill_fields: [
+      field_or_set,
+      field_or_set
+    ]
     can_filter: no
     fanout_on: repeated_record_name
-    tags: ["string1", "string2"]
+    tags: [
+      "string1",
+      "string2"
+    ]
     type: field_type
     primary_key: no
     case: {
@@ -160,7 +193,10 @@ view: view_name {
       }
     }
     alpha_sort: no
-    tiers: [N, N]
+    tiers: [
+      N,
+      N
+    ]
     style: relational
     sql_latitude: SQL expression to generate a latitude ;;
     sql_longitude: SQL expression to generate a longitude ;;
@@ -168,7 +204,10 @@ view: view_name {
     suggest_persist_for: "N hours"
     suggest_dimension: dimension_name
     suggest_explore: explore_name
-    suggestions: ["suggestion string", "suggestion string"]
+    suggestions: [
+      "suggestion string",
+      "suggestion string"
+    ]
     allowed_value: {
       label: "desired label name"
       value: "looker filter expression"
@@ -177,7 +216,10 @@ view: view_name {
       label: "desired label name"
       value: "looker filter expression"
     }
-    required_access_grants: [access_grant_name, access_grant_name]
+    required_access_grants: [
+      access_grant_name,
+      access_grant_name
+    ]
     bypass_suggest_restrictions: no
     full_suggestions: no
     skip_drill_filter: no
@@ -194,10 +236,16 @@ view: view_name {
       url: "desired_url"
       icon_url: "url_of_an_ico_file"
     }
-    timeframes: [timeframe, timeframe]
+    timeframes: [
+      timeframe,
+      timeframe
+    ]
     convert_tz: no
     datatype: timestamp
-    intervals: [interval, interval]
+    intervals: [
+      interval,
+      interval
+    ]
     sql_start: SQL expression for start time of duration ;;
     sql_end: SQL expression for end time of duration ;;
     direction: "column"

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -222,13 +222,6 @@ def test_write_any_with_dict_value_and_name(serializer):
     )
 
 
-def test_write_any_with_dict_value_and_name(serializer):
-    generator = serializer.write_any(key="dimension", value={"label": "Dimension Name"})
-    result = "".join(generator)
-    print(result)
-    assert result == "".join(("dimension: {\n", '  label: "Dimension Name"\n', "}"))
-
-
 def test_expand_list_with_blocks(serializer):
     generator = serializer.expand_list(
         key="dimensions", values=[{"name": "dimension_one"}, {"name": "dimension_two"}]

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -48,7 +48,9 @@ def test_write_set_with_unquoted_literals(serializer):
     )
     result = "".join(generator)
     print(result)
-    assert result == "fields: [dimension_one, dimension_two, dimension_three]"
+    assert (
+        result == "fields: [\n  dimension_one,\n  dimension_two,\n  dimension_three\n]"
+    )
 
 
 def test_write_set_with_quoted_literals(serializer):
@@ -57,7 +59,9 @@ def test_write_set_with_quoted_literals(serializer):
     )
     result = "".join(generator)
     print(result)
-    assert result == 'sortkeys: ["column_one", "column_two", "column_three"]'
+    assert (
+        result == 'sortkeys: [\n  "column_one",\n  "column_two",\n  "column_three"\n]'
+    )
 
 
 def test_write_set_with_many_values(serializer):
@@ -204,7 +208,7 @@ def test_write_any_with_list_value(serializer):
     generator = serializer.write_any(key="sortkeys", value=["column_one", "column_two"])
     result = "".join(generator)
     print(result)
-    assert result == 'sortkeys: ["column_one", "column_two"]'
+    assert result == 'sortkeys: [\n  "column_one",\n  "column_two"\n]'
 
 
 def test_write_any_with_dict_value_and_name(serializer):


### PR DESCRIPTION
Creating this PR as a suggestion: please feel free to disagree & close! 🙂

Previously, sets with fewer than 5 keys were represented on a single line, whereas larger sets were broken up with one element per line. Now, all sets are serialized with the latter behavior.

I see two cases where always expanding sets is useful:

1. When the key elements are long & the length of the line exceeds the recommended ~80-90 columns, despite there being fewer than 5 elements
1. When a set has fewer than 5 elements, but more are added. Having consistent formatting rules will result in marginally smaller diffs.