### PR TITLE
Remove sql_where from plural keys

### DIFF
--- a/lkml/keys.py
+++ b/lkml/keys.py
@@ -32,7 +32,6 @@ PLURAL_KEYS: Tuple[str, ...] = (
     "datagroup",
     "access_grant",
     "sql_step",
-    "sql_where",
     "action",
     "param",
     "form_param",


### PR DESCRIPTION
Multiple statements of `sql_where` are allowed by Looker's validator. However, Looker only uses the last statement in the actual SQL join. Normally I prefer to follow the behavior of the Looker validator, but in this case, I disagree with the way the validator works (it should raise an error for 2 statements supplied if only 1 will be used) and will allow `lkml` to raise an error when there are multiple sql_where statements in a single join.