### PR TITLE
Support LookML data tests

### DIFF
--- a/lkml/keys.py
+++ b/lkml/keys.py
@@ -37,12 +37,15 @@ PLURAL_KEYS: Tuple[str, ...] = (
     "form_param",
     "option",
     "user_attribute_param",
+    "assert",
+    "test",
 )
 
 # These are keys in LookML that should be recognized as expression blocks (end with ;;).
 
 EXPR_BLOCK_KEYS: Tuple[str, ...] = (
     "expression_custom_filter",
+    "expression",
     "html",
     "sql_trigger_value",
     "sql_table_name",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 here = Path(__file__).parent.resolve()
 

--- a/tests/resources/model_with_all_fields.model.lkml
+++ b/tests/resources/model_with_all_fields.model.lkml
@@ -51,6 +51,42 @@ access_grant: access_grant_name {
   allowed_values: ["value_1", "value_2"]
 }
 
+test: data_test_name {
+  explore_source: explore_name {
+    column: column_name {
+      field: view_name.dimension_name
+    }
+    filters: {
+      field: view_name.dimension_name
+      value: "value"
+    }
+  }
+  assert: assertion_name {
+    expression: ${view_name.dimension_name} = 626000 ;;
+  }
+  assert: assertion_name {
+    expression: ${view_name.dimension_name} = 'value' ;;
+  }
+}
+
+test: data_test_name {
+  explore_source: explore_name {
+    column: column_name {
+      field: view_name.dimension_name
+    }
+    filters: {
+      field: view_name.dimension_name
+      value: "value"
+    }
+  }
+  assert: assertion_name {
+    expression: ${view_name.dimension_name} = 626000 ;;
+  }
+  assert: assertion_name {
+    expression: ${view_name.dimension_name} = 'value' ;;
+  }
+}
+
 explore: view_name {
   description: "description string"
   label: "desired label name"

--- a/tests/resources/view_with_all_fields.view.lkml
+++ b/tests/resources/view_with_all_fields.view.lkml
@@ -1,3 +1,42 @@
+include: "filename_or_pattern"
+include: "filename_or_pattern"
+
+test: data_test_name {
+  explore_source: explore_name {
+    column: column_name {
+      field: view_name.dimension_name
+    }
+    filters: {
+      field: view_name.dimension_name
+      value: "value"
+    }
+  }
+  assert: assertion_name {
+    expression: ${view_name.dimension_name} = 626000 ;;
+  }
+  assert: assertion_name {
+    expression: ${view_name.dimension_name} = 'value' ;;
+  }
+}
+
+test: data_test_name {
+  explore_source: explore_name {
+    column: column_name {
+      field: view_name.dimension_name
+    }
+    filters: {
+      field: view_name.dimension_name
+      value: "value"
+    }
+  }
+  assert: assertion_name {
+    expression: ${view_name.dimension_name} = 626000 ;;
+  }
+  assert: assertion_name {
+    expression: ${view_name.dimension_name} = 'value' ;;
+  }
+}
+
 view: view_name {
   sql_table_name: table_name ;;
   suggestions: no

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,3 +31,8 @@ def test_run_cli(mock_parse_args, mock_load, lookml_path):
     mock_parse_args.return_value.log_level = logging.WARN
     mock_load.return_value = {"a": 1}
     lkml.cli()
+
+
+def test_load_with_bad_argument_raises_type_error():
+    with pytest.raises(TypeError):
+        lkml.load(stream=100)


### PR DESCRIPTION
Adds support for LookML [data tests](https://docs.looker.com/reference/model-params/test) which are used for unit test-like assertions in LookML.

Adds two new plural keys: `assert` and `test` and a new expression block key `expression`.