### PR TITLE
Improve the write_any TypeError message

### DIFF
--- a/lkml/serializer.py
+++ b/lkml/serializer.py
@@ -137,7 +137,7 @@ class Serializer:
                 name = value.pop("name")
             yield from self.write_block(key, value, name)
         else:
-            raise TypeError("Value must be a string, list, tuple, or dict.")
+            raise TypeError("Value must be a string, list, tuple, or dict. Got %s." % type(value))
 
         self.field_counter += 1
 


### PR DESCRIPTION
It can be somewhat annoying to find out the source of the `TypeError`, especially if you're generating a lot of lookml code automatically.

Including the type of the value in the message would help this a lot.