### PR TITLE
Make leading and trailing commas SyntaxTokens

### DIFF
--- a/lkml/__init__.py
+++ b/lkml/__init__.py
@@ -121,7 +121,3 @@ def cli():
 
     json_string = json.dumps(result, indent=2)
     print(json_string)
-
-
-if __name__ == "__main__":
-    cli()

--- a/lkml/__main__.py
+++ b/lkml/__main__.py
@@ -1,0 +1,4 @@
+if __name__ == "__main__":
+    from lkml import cli
+
+    cli()

--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -459,8 +459,6 @@ class Parser:
                 left_bracket=left_bracket,
                 items=csv.values,
                 right_bracket=right_bracket,
-                trailing_comma=csv.trailing_comma,
-                leading_comma=csv.leading_comma,
             )
             if self.log_debug:
                 logger.debug("%sSuccessfully parsed a list.", self.depth * DELIMITER)
@@ -491,10 +489,9 @@ class Parser:
         pair_mode: bool = False
         csv = CommaSeparatedValues()
 
-        # Allow leading comma
-        if self.check(tokens.CommaToken):
-            csv.leading_comma = True
-            self.advance()
+        leading_comma = self.parse_comma()
+        if leading_comma:
+            csv.append(leading_comma)
 
         # Parse the first value to set the list's type
         pair = self.parse_pair()
@@ -541,3 +538,12 @@ class Parser:
                 "%sSuccessfully parsed comma-separated values.", self.depth * DELIMITER
             )
         return csv
+
+    @backtrack_if_none
+    def parse_comma(self) -> Optional[tree.Comma]:
+        prefix = self.consume_trivia()
+        if self.check(tokens.CommaToken):
+            self.advance()
+            return tree.Comma(prefix=prefix, suffix=self.consume_trivia())
+        else:
+            return None

--- a/lkml/simple.py
+++ b/lkml/simple.py
@@ -19,6 +19,7 @@ from lkml.keys import (
 )
 from lkml.tree import (
     BlockNode,
+    Comma,
     ContainerNode,
     DocumentNode,
     ExpressionSyntaxToken,
@@ -396,7 +397,7 @@ class DictParser:
 
         # Choose newline delimiting or space delimiting based on contents
         if len(values) >= 5 or pair_mode:
-            trailing_comma = True
+            trailing_comma: Optional[Comma] = Comma()
             self.increase_level()
             for value in values:
                 if pair_mode:
@@ -414,7 +415,7 @@ class DictParser:
             self.decrease_level()
             right_bracket = RightBracket(prefix=self.newline_indent)
         else:
-            trailing_comma = False
+            trailing_comma = None
             for i, value in enumerate(values):
                 value = cast(str, value)
                 if i == 0:

--- a/lkml/tree.py
+++ b/lkml/tree.py
@@ -168,6 +168,7 @@ class ListNode(SyntaxNode):
     right_bracket: RightBracket
     colon: Colon = Colon(suffix=" ")
     trailing_comma: bool = False
+    leading_comma: bool = False
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(type='{self.type.value}')"
@@ -190,6 +191,7 @@ class ListNode(SyntaxNode):
             self.type,
             self.colon,
             self.left_bracket,
+            "," if self.leading_comma and len(self.items) > 0 else "",
             ",".join(str(item) for item in self.items),
             "," if self.trailing_comma and len(self.items) > 0 else "",
             self.right_bracket,

--- a/lkml/tree.py
+++ b/lkml/tree.py
@@ -76,6 +76,11 @@ class DoubleSemicolon(SyntaxToken):
     value: str = ";;"
 
 
+@dataclass(frozen=True)
+class Comma(SyntaxToken):
+    value: str = ","
+
+
 class QuotedSyntaxToken(SyntaxToken):
     def format_value(self) -> str:
         # Escape double quotes since the whole value is quoted
@@ -167,8 +172,6 @@ class ListNode(SyntaxNode):
     left_bracket: LeftBracket
     right_bracket: RightBracket
     colon: Colon = Colon(suffix=" ")
-    trailing_comma: bool = False
-    leading_comma: bool = False
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(type='{self.type.value}')"

--- a/lkml/tree.py
+++ b/lkml/tree.py
@@ -172,6 +172,8 @@ class ListNode(SyntaxNode):
     left_bracket: LeftBracket
     right_bracket: RightBracket
     colon: Colon = Colon(suffix=" ")
+    leading_comma: Optional[Comma] = None
+    trailing_comma: Optional[Comma] = None
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(type='{self.type.value}')"
@@ -194,9 +196,9 @@ class ListNode(SyntaxNode):
             self.type,
             self.colon,
             self.left_bracket,
-            "," if self.leading_comma and len(self.items) > 0 else "",
+            self.leading_comma if self.leading_comma and len(self.items) > 0 else "",
             ",".join(str(item) for item in self.items),
-            "," if self.trailing_comma and len(self.items) > 0 else "",
+            self.trailing_comma if self.trailing_comma and len(self.items) > 0 else "",
             self.right_bracket,
         )
 

--- a/tests/resources/lists_with_comma_configurations.view.lkml
+++ b/tests/resources/lists_with_comma_configurations.view.lkml
@@ -21,3 +21,7 @@ fields: [
 fields: [
     , a, b, c
 ]
+
+fields: [
+    , a, b, c , 
+]

--- a/tests/resources/lists_with_comma_configurations.view.lkml
+++ b/tests/resources/lists_with_comma_configurations.view.lkml
@@ -8,7 +8,11 @@ fields: []
 
 fields: [a, b, c]
 
+fields: [ a , b , c ]
+
 fields: [a, b, c,]
+
+fields: [a, b, c  , ]
 
 fields: [
     a, b, c,

--- a/tests/resources/lists_with_comma_configurations.view.lkml
+++ b/tests/resources/lists_with_comma_configurations.view.lkml
@@ -1,27 +1,37 @@
-fields: [
-    , a
-    , b
-    , c
-]
+view: lots_of_sets {
+    set: a {
+        fields: [
+            , a
+            , b
+            , c
+        ]
+    }
 
-fields: []
+    set: b { fields: [] }
 
-fields: [a, b, c]
+    set: c { fields: [a, b, c] }
 
-fields: [ a , b , c ]
+    set: d { fields: [ a , b , c ] }
 
-fields: [a, b, c,]
+    set: e { fields: [a, b, c,] }
 
-fields: [a, b, c  , ]
+    set: f {fields: [a, b, c  , ] }
 
-fields: [
-    a, b, c,
-]
+    set: g {
+        fields: [
+            a, b, c,
+        ]
+    }
 
-fields: [
-    , a, b, c
-]
+    set: h { 
+        fields: [
+            , a, b, c
+        ]
+    }
 
-fields: [
-    , a, b, c , 
-]
+    set: i {
+        fields: [
+            , a, b, c , 
+        ]
+    }
+}

--- a/tests/resources/lists_with_comma_configurations.view.lkml
+++ b/tests/resources/lists_with_comma_configurations.view.lkml
@@ -1,0 +1,19 @@
+fields: [
+    , a
+    , b
+    , c
+]
+
+fields: []
+
+fields: [a, b, c]
+
+fields: [a, b, c,]
+
+fields: [
+    a, b, c,
+]
+
+fields: [
+    , a, b, c
+]

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -94,6 +94,11 @@ def test_duplicate_non_top_level_keys():
         load("duplicate_non_top_level_keys.view.lkml")
 
 
+def test_lists_with_comma_configurations():
+    parsed = load("lists_with_comma_configurations.view.lkml")
+    assert parsed is not None
+
+
 def test_reserved_dimension_names():
     parsed = load("block_with_reserved_dimension_names.view.lkml")
     assert parsed is not None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,6 +4,7 @@ import lkml
 import lkml.tokens as tokens
 from lkml.tokens import CommaToken, LiteralToken, ValueToken, WhitespaceToken
 from lkml.tree import (
+    Comma,
     LeftCurlyBrace,
     RightCurlyBrace,
     SyntaxToken,
@@ -422,8 +423,8 @@ def test_parse_list_with_trailing_comma():
         type=SyntaxToken("drill_fields"),
         left_bracket=LeftBracket(),
         items=(SyntaxToken("view_name.field_one"),),
+        trailing_comma=Comma(),
         right_bracket=RightBracket(),
-        trailing_comma=True,
     )
 
     # Test when the list items are separated by newlines
@@ -445,8 +446,8 @@ def test_parse_list_with_trailing_comma():
         type=SyntaxToken("drill_fields"),
         left_bracket=LeftBracket(),
         items=(SyntaxToken("view_name.field_one", prefix="\n  "),),
+        trailing_comma=Comma(),
         right_bracket=RightBracket(prefix="\n"),
-        trailing_comma=True,
     )
 
 
@@ -468,8 +469,9 @@ def test_parse_list_with_leading_comma():
         left_bracket=LeftBracket(),
         items=(SyntaxToken("view_name.field_one"),),
         right_bracket=RightBracket(),
-        leading_comma=True,
+        leading_comma=Comma(),
     )
+
 
 def test_parse_list_with_missing_comma():
     stream = (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,7 +2,7 @@ from lkml.parser import Syntax
 import pytest
 import lkml
 import lkml.tokens as tokens
-from lkml.tokens import LiteralToken, ValueToken, WhitespaceToken
+from lkml.tokens import CommaToken, LiteralToken, ValueToken, WhitespaceToken
 from lkml.tree import (
     LeftCurlyBrace,
     RightCurlyBrace,
@@ -449,6 +449,27 @@ def test_parse_list_with_trailing_comma():
         trailing_comma=True,
     )
 
+
+def test_parse_list_with_leading_comma():
+    stream = (
+        tokens.LiteralToken("drill_fields", 1),
+        tokens.ValueToken(1),
+        tokens.WhitespaceToken(" ", 1),
+        tokens.ListStartToken(1),
+        tokens.CommaToken(1),
+        tokens.LiteralToken("view_name.field_one", 1),
+        tokens.ListEndToken(1),
+        tokens.StreamEndToken(1),
+    )
+    parser = lkml.parser.Parser(stream)
+    result = parser.parse_list()
+    assert result == ListNode(
+        type=SyntaxToken("drill_fields"),
+        left_bracket=LeftBracket(),
+        items=(SyntaxToken("view_name.field_one"),),
+        right_bracket=RightBracket(),
+        leading_comma=True,
+    )
 
 def test_parse_list_with_missing_comma():
     stream = (


### PR DESCRIPTION
Closes #60.

Treats leading and trailing commas as syntax tokens with their own prefixes and suffixes.

In the case of `[ , a, b, c  , ]`, the leading and trailing commas themselves must have their own prefixes and suffixes, otherwise it's ambiguous where to assign the space immediately following `[` and preceding `]`.