### PR TITLE
Include line numbers in syntax tokens and nodes

### DIFF
--- a/lkml/simple.py
+++ b/lkml/simple.py
@@ -475,8 +475,8 @@ class DictParser:
 
         """
         if force_quote or key in QUOTED_LITERAL_KEYS:
-            return QuotedSyntaxToken(value, prefix, suffix)
+            return QuotedSyntaxToken(value, prefix=prefix, suffix=suffix)
         elif key in EXPR_BLOCK_KEYS:
-            return ExpressionSyntaxToken(value.strip(), prefix, suffix)
+            return ExpressionSyntaxToken(value.strip(), prefix=prefix, suffix=suffix)
         else:
-            return SyntaxToken(value, prefix, suffix)
+            return SyntaxToken(value, prefix=prefix, suffix=suffix)


### PR DESCRIPTION
lkml collects the line numbers of Lexer tokens, but never transfers them to the parse tree during parsing. This is a useful feature for things like style checkers that need to tie a SyntaxNode or SyntaxToken to a specific line of LookML.