### PR TITLE
Support type-checking

### DIFF
--- a/lkml/tree.py
+++ b/lkml/tree.py
@@ -190,13 +190,13 @@ class ListNode(SyntaxNode):
         return f"{self.__class__.__name__}(type='{self.type.value}')"
 
     @property
-    def children(self,) -> Optional[Tuple[PairNode, ...]]:
-        if isinstance(self.items[0], PairNode):
+    def children(self,) -> Tuple[PairNode, ...]:
+        if self.items and isinstance(self.items[0], PairNode):
             # Assume that all elements are pairs
             self.items = cast(Tuple[PairNode, ...], self.items)  # type: ignore
             return self.items
         else:
-            return None
+            return tuple()
 
     @property
     def line_number(self) -> Optional[int]:
@@ -245,8 +245,8 @@ class BlockNode(SyntaxNode):
         return f"{self.__class__.__name__}(type='{self.type.value}', {name})"
 
     @property
-    def children(self) -> Optional[Tuple[ContainerNode, ...]]:
-        return (self.container,) if self.container else None
+    def children(self) -> Tuple[ContainerNode, ...]:
+        return (self.container,) if self.container else tuple()
 
     @property
     def line_number(self) -> Optional[int]:
@@ -281,7 +281,7 @@ class DocumentNode(SyntaxNode):
 
     @property
     def children(self) -> Tuple[ContainerNode]:
-        return (self.container,)  # type: ignore
+        return (self.container,)
 
     @property
     def line_number(self) -> Optional[int]:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-__version__ = "1.1.2"
+__version__ = "1.3.0b1"
 
 here = Path(__file__).parent.resolve()
 
@@ -34,4 +34,5 @@ setup(
     author="Josh Temple",
     tests_require=["black", "flake8", "isort", "mypy", "pytest", "pytest-cov"],
     author_email="",
+    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-__version__ = "1.3.0b1"
+__version__ = "1.3.0b2"
 
 here = Path(__file__).parent.resolve()
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     license="MIT",
     entry_points={"console_scripts": ["lkml = lkml.__init__:cli"]},
     packages=find_packages(exclude=["docs", "tests*", "scripts"]),
+    package_data={"lkml": ["py.typed"]},
     include_package_data=True,
     author="Josh Temple",
     tests_require=["black", "flake8", "isort", "mypy", "pytest", "pytest-cov"],


### PR DESCRIPTION
This change adds a `py.typed` file to support type-checking with `mypy` in downstream libraries. It also makes some improvements to the type hints to make them more logical in some places.