### PR TITLE
Fix leading commas in lists with whitespace

### DIFF
--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -335,7 +335,7 @@ class Parser:
         key = self.parse_key()
         if key is None:
             return None
-        value = self.parse_value()
+        value = self.parse_value(parse_prefix=True, parse_suffix=True)
         if value is None:
             return None
 

--- a/tests/resources/lists_with_comma_configurations.view.lkml
+++ b/tests/resources/lists_with_comma_configurations.view.lkml
@@ -23,6 +23,13 @@ view: lots_of_sets {
         ]
     }
 
+    set: g2 {
+        fields: [a
+        ,   b
+        ,   c
+        ]
+    }
+
     set: h { 
         fields: [
             , a, b, c
@@ -32,6 +39,30 @@ view: lots_of_sets {
     set: i {
         fields: [
             , a, b, c , 
+        ]
+    }
+
+    measure: j {
+        filters: [a: "b", c: "d"]
+    }
+
+    measure: k {
+        filters: [
+            a: "b",
+            c: "d"
+        ]
+    }
+
+    measure: k {
+        filters: [a: "b" ,
+            c: "d",
+        ]
+    }
+
+    measure: l {
+        filters: [a: "b"
+            , c: "d"
+            , e: "f"
         ]
     }
 }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -419,10 +419,10 @@ def test_parse_list_with_pairs():
             PairNode(
                 type=SyntaxToken("view_name.field_one", 2, prefix="\n  "),
                 colon=Colon(line_number=2, suffix=" "),
-                value=QuotedSyntaxToken("-0,-1,-8,-9,-99,-NULL,-EMPTY", 2),
+                value=QuotedSyntaxToken("-0,-1,-8,-9,-99,-NULL,-EMPTY", 2, suffix="\n"),
             ),
         ),
-        right_bracket=RightBracket(prefix="\n"),
+        right_bracket=RightBracket(),
     )
 
 


### PR DESCRIPTION
This change forces the `parse_pair` method to parse prefixes and suffixes for values inside. It's not clear to me if this puts the trivia in a sensible place, but it resolves the issue with parsing.

Closes #59.