### PR TITLE
Stop mutating input in `lkml.dump`

### DIFF
--- a/lkml/simple.py
+++ b/lkml/simple.py
@@ -7,6 +7,7 @@ to interact with the parse tree.
 """
 
 import logging
+import copy
 from typing import Any, Dict, List, Optional, Sequence, Type, Union, cast
 
 from lkml.keys import (
@@ -306,6 +307,7 @@ class DictParser:
             A generator of serialized string chunks
 
         """
+
         if isinstance(value, str):
             return self.parse_pair(key, value)
         elif isinstance(value, (list, tuple)):
@@ -314,11 +316,12 @@ class DictParser:
             else:
                 return self.parse_list(key, value)
         elif isinstance(value, dict):
+            to_parse = copy.copy(value)
             if key in KEYS_WITH_NAME_FIELDS or "name" not in value.keys():
                 name = None
             else:
-                name = value.pop("name")
-            return self.parse_block(key, value, name)
+                name = to_parse.pop("name")
+            return self.parse_block(key, to_parse, name)
         else:
             raise TypeError("Value must be a string, list, tuple, or dict.")
 

--- a/lkml/simple.py
+++ b/lkml/simple.py
@@ -6,8 +6,8 @@ to interact with the parse tree.
 
 """
 
-import logging
 import copy
+import logging
 from typing import Any, Dict, List, Optional, Sequence, Type, Union, cast
 
 from lkml.keys import (

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 here = Path(__file__).parent.resolve()
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -102,3 +102,21 @@ def test_lists_with_comma_configurations():
 def test_reserved_dimension_names():
     parsed = load("block_with_reserved_dimension_names.view.lkml")
     assert parsed is not None
+
+
+def test_repeated_dump_does_not_mutate_input():
+    text = """view: albums {
+        dimension: id {
+            primary_key: yes
+            type: number
+            sql: ${TABLE}.album_id ;;
+        }
+    }
+    """
+
+    tree = lkml.parse(text)
+    visitor = lkml.DictVisitor()
+    parsed: dict = visitor.visit(tree)
+    first = lkml.dump(parsed)
+    second = lkml.dump(parsed)
+    assert first == second


### PR DESCRIPTION
We shouldn't directly mutate the input when calling `.dump` in case it needs to be reused by the user. Instead, we should make a copy before operating on it.

Closes #61.