### PR TITLE
Move non-breaking leading whitespace to block prefix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
 sphinx:
   configuration: docs/source/conf.py
 

--- a/lkml/keys.py
+++ b/lkml/keys.py
@@ -107,6 +107,7 @@ QUOTED_LITERAL_KEYS: Tuple[str, ...] = (
     "property_key",
     "property_label_key",
     "else",
+    "interval_trigger",
 )
 
 # These are keys for fields in Looker that have a "name" attribute. Since lkml uses the

--- a/lkml/lexer.py
+++ b/lkml/lexer.py
@@ -1,6 +1,6 @@
 """Splits a LookML string into a sequence of tokens."""
 
-from typing import List, Tuple, Union
+from typing import List, Tuple
 
 import lkml.tokens as tokens
 from lkml.keys import CHARACTER_TO_TOKEN, EXPR_BLOCK_KEYS
@@ -124,7 +124,7 @@ class Lexer:
                 chars += self.consume()
                 next_char = self.peek()
         return tokens.InlineWhitespaceToken(chars, self.line_number)
-    
+
     def scan_comment(self) -> tokens.CommentToken:
         r"""Returns a token from a comment.
 

--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -151,7 +151,7 @@ class Parser:
             valid_tokens += (tokens.LinebreakToken,)
         else:
             valid_tokens += (tokens.WhitespaceToken,)
-        
+
         trivia = ""
         while True:
             if self.check(*valid_tokens):

--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -146,7 +146,7 @@ class Parser:
 
     def consume_trivia(self, only_newlines: bool = False) -> str:
         """Returns all continuous trivia values."""
-        valid_tokens = (tokens.CommentToken,)
+        valid_tokens: Tuple[Type[tokens.TriviaToken], ...] = (tokens.CommentToken,)
         if only_newlines:
             valid_tokens += (tokens.LinebreakToken,)
         else:

--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -144,11 +144,17 @@ class Parser:
             raise ValueError("Token %s does not have a consumable value." % token)
         return token.value
 
-    def consume_trivia(self) -> str:
+    def consume_trivia(self, only_newlines: bool = False) -> str:
         """Returns all continuous trivia values."""
+        valid_tokens = (tokens.CommentToken,)
+        if only_newlines:
+            valid_tokens += (tokens.LinebreakToken,)
+        else:
+            valid_tokens += (tokens.WhitespaceToken,)
+        
         trivia = ""
         while True:
-            if self.check(tokens.CommentToken, tokens.WhitespaceToken):
+            if self.check(*valid_tokens):
                 trivia += self.consume_token_value()
             else:
                 break
@@ -192,7 +198,7 @@ class Parser:
             # Reached the end of the stream
             result = False
         else:
-            if type(token) in token_types:
+            if isinstance(token, token_types):
                 result = True
             else:
                 result = False
@@ -300,7 +306,7 @@ class Parser:
         prefix = self.consume_trivia()
         if self.check(tokens.BlockEndToken):
             self.advance()
-            suffix = self.consume_trivia()
+            suffix = self.consume_trivia(only_newlines=True)
             right_brace = tree.RightCurlyBrace(prefix=prefix, suffix=suffix)
 
             block = tree.BlockNode(

--- a/lkml/tokens.py
+++ b/lkml/tokens.py
@@ -120,7 +120,6 @@ class ListEndToken(Token):
 class TriviaToken(ContentToken):
     """Represents a comment or whitespace."""
 
-
 class WhitespaceToken(TriviaToken):
     """Represents one or more whitespace characters."""
 
@@ -128,6 +127,16 @@ class WhitespaceToken(TriviaToken):
 
     def __repr__(self):
         return f"{self.__class__.__name__}({repr(self.value)})"
+
+class LinebreakToken(WhitespaceToken):
+    """Represents a newline character."""
+
+    id = "<linebreak>"
+
+class InlineWhitespaceToken(WhitespaceToken):
+    """Represents one or more whitespace characters."""
+
+    id = "<inline whitespace>"
 
 
 class CommentToken(TriviaToken):

--- a/lkml/tokens.py
+++ b/lkml/tokens.py
@@ -120,6 +120,7 @@ class ListEndToken(Token):
 class TriviaToken(ContentToken):
     """Represents a comment or whitespace."""
 
+
 class WhitespaceToken(TriviaToken):
     """Represents one or more whitespace characters."""
 
@@ -128,10 +129,12 @@ class WhitespaceToken(TriviaToken):
     def __repr__(self):
         return f"{self.__class__.__name__}({repr(self.value)})"
 
+
 class LinebreakToken(WhitespaceToken):
     """Represents a newline character."""
 
     id = "<linebreak>"
+
 
 class InlineWhitespaceToken(WhitespaceToken):
     """Represents one or more whitespace characters."""

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 here = Path(__file__).parent.resolve()
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -81,7 +81,9 @@ def test_scan_whitespace():
     text = "\n\t Hello World!"
     lexer = lkml.Lexer(text)
     token = lexer.scan_whitespace()
-    assert token == tokens.WhitespaceToken("\n\t ", 1)
+    assert token == tokens.LinebreakToken("\n", 1)
+    token = lexer.scan_whitespace()
+    assert token == tokens.InlineWhitespaceToken("\t ", 2)
 
 
 def test_scan_comment():
@@ -97,9 +99,10 @@ def test_scan_comment_with_surrounding_whitespace():
     output = lkml.Lexer(text).scan()
     assert output == (
         tokens.StreamStartToken(1),
-        tokens.WhitespaceToken("\n", 1),
+        tokens.LinebreakToken("\n", 1),
         tokens.CommentToken("# A comment", 2),
-        tokens.WhitespaceToken("\n ", 2),
+        tokens.LinebreakToken("\n", 2),
+        tokens.InlineWhitespaceToken(" ", 3),
         tokens.StreamEndToken(3),
     )
 
@@ -173,7 +176,7 @@ def test_scan_with_non_expression_block_starting_with_sql():
         tokens.StreamStartToken(1),
         tokens.LiteralToken("sql_not_reserved_field", 1),
         tokens.ValueToken(1),
-        tokens.WhitespaceToken(" ", 1),
+        tokens.InlineWhitespaceToken(" ", 1),
         tokens.LiteralToken("yes", 1),
         tokens.StreamEndToken(1),
     )
@@ -186,7 +189,7 @@ def test_scan_with_non_expression_block_starting_with_html():
         tokens.StreamStartToken(1),
         tokens.LiteralToken("html_not_reserved_field", 1),
         tokens.ValueToken(1),
-        tokens.WhitespaceToken(" ", 1),
+        tokens.InlineWhitespaceToken(" ", 1),
         tokens.LiteralToken("yes", 1),
         tokens.StreamEndToken(1),
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -706,5 +706,5 @@ def test_parse_block_with_no_expression():
         colon=Colon(line_number=1, suffix=" "),
         left_brace=LeftCurlyBrace(prefix=" "),
         container=ContainerNode(items=tuple()),
-        right_brace=RightCurlyBrace(suffix=" "),
+        right_brace=RightCurlyBrace(),
     )


### PR DESCRIPTION
### Support `interval_trigger`

Closes #78.

### Reassign block prefix whitespace

Previously, parsing text like this...

```lookml
view: view {
  dimension: d1 {
    ...
  }

  dimension: d2 {
    ...
  }
}
```

...would assign all whitespace between the two dimensions to the suffix of the first dimension.

It's _slightly_ more accurate to assign the newlines to the suffix of the first dimension and the non-breaking whitespace characters (spaces) to the prefix of the second dimension.

This is useful for a case where we want to dump the second dimension in isolation to a string. In the current version of the code, we lose the leading whitespace, so we get this:

```lookml
dimension: d2 {
    ...
  }
```

Note that the word `dimension` and the closing `}` are not aligned.

After this change, we get:

```lookml
  dimension: d2 {
    ...
  }
```

Which is much more consistent and easier to strip the leading indent off of.