### PR TITLE
Parse sets with values that have whitespace following leading hyphens

### DIFF
--- a/lkml/parser.py
+++ b/lkml/parser.py
@@ -406,6 +406,13 @@ class Parser:
 
         if self.check(tokens.LiteralToken):
             token = self.consume()
+            # Handle special case where a hyphen can be preceded by whitspace
+            if token.value == "-" and self.consume_trivia():
+                if self.check(tokens.LiteralToken):
+                    token = self.consume()
+                    token.value = "-" + token.value
+                else:
+                    return None
             suffix = self.consume_trivia() if parse_suffix else ""
             if self.log_debug:
                 logger.debug("%sSuccessfully parsed value.", self.depth * DELIMITER)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 here = Path(__file__).parent.resolve()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -722,7 +722,7 @@ def test_parse_list_with_space_delimited_hyphen():
         type=SyntaxToken("fields", 1),
         colon=Colon(line_number=1, suffix=" "),
         left_bracket=LeftBracket(),
-        items=(SyntaxToken("- view.dimension_name", 1, prefix=" "),),
+        items=(SyntaxToken("-view.dimension_name", 1, prefix=" "),),
         right_bracket=RightBracket(),
     )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -703,6 +703,30 @@ def test_parse_list_with_only_comment():
     )
 
 
+def test_parse_list_with_space_delimited_hyphen():
+    stream = (
+        tokens.LiteralToken("fields", 1),
+        tokens.ValueToken(1),
+        tokens.WhitespaceToken(" ", 1),
+        tokens.ListStartToken(1),
+        tokens.WhitespaceToken(" ", 1),
+        tokens.LiteralToken("-", 1),
+        tokens.WhitespaceToken(" ", 1),
+        tokens.LiteralToken("view.dimension_name", 1),
+        tokens.ListEndToken(1),
+        tokens.StreamEndToken(1),
+    )
+    parser = lkml.parser.Parser(stream)
+    result = parser.parse_list()
+    assert result == ListNode(
+        type=SyntaxToken("fields", 1),
+        colon=Colon(line_number=1, suffix=" "),
+        left_bracket=LeftBracket(),
+        items=(SyntaxToken("- view.dimension_name", 1, prefix=" "),),
+        right_bracket=RightBracket(),
+    )
+
+
 def test_parse_block_with_no_expression():
     stream = (
         tokens.LiteralToken("dimension", 1),


### PR DESCRIPTION
Closes #86

Note: This breaks the typical paradigm of lkml, which is that round-trip parsing should be possible (parsing and then dumping again should result in the same string).

I've decided to be slightly opinionated here: parsing `fields: [ - view.dimension_name ]` and then dumping it will result in `fields: [ -view.dimension_name ]`. Otherwise, I have to support a tricky concept: two literal tokens ('-', 'view.dimension_name') representing a single value in a list, or I have to support a literal token having spaces inside, which makes no sense.

I'm comfortable with this because I don't think `- view.dimension_name` is a _good_ way to write LookML and shouldn't be actively supported beyond parsing without errors.