### PR TITLE
Add cli options to output lookml 

### DIFF
--- a/lkml/__init__.py
+++ b/lkml/__init__.py
@@ -143,7 +143,8 @@ def cli():
         dump(result, args.file)
         args.file.truncate()
     elif args.lookml:
-        print(dump(result))
+        lookml_string = dump(result)
+        print(lookml_string)
     elif args.json:
         json_string = json.dumps(result, indent=2)
         print(json_string)

--- a/lkml/__init__.py
+++ b/lkml/__init__.py
@@ -4,8 +4,7 @@ import argparse
 import io
 import json
 import logging
-import sys
-from typing import IO, Optional, Sequence, Union
+from typing import IO, Optional, Union
 
 from lkml.lexer import Lexer
 from lkml.parser import Parser
@@ -74,7 +73,7 @@ def dump(obj: dict, file_object: IO = None) -> Optional[str]:
         return result
 
 
-def parse_args(args: Sequence) -> argparse.Namespace:
+def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         description=(
@@ -117,7 +116,7 @@ def parse_args(args: Sequence) -> argparse.Namespace:
         help="parse and write back to the LookML file",
     )
 
-    return parser.parse_args(args)
+    return parser.parse_args()
 
 
 def cli():
@@ -133,7 +132,7 @@ def cli():
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
-    args = parse_args(sys.argv[1:])
+    args = parse_args()
 
     logging.getLogger().setLevel(args.log_level)
 


### PR DESCRIPTION
This should close https://github.com/joshtemple/lkml/issues/88.

```
> lkml --help
usage: lkml [-h] [-v] [--json | --lookml | -f] file

A blazing fast LookML parser, implemented in pure Python. When invoked from the command line, returns the parsed
output as a JSON string.

positional arguments:
  file           path to the LookML file to parse

options:
  -h, --help     show this help message and exit
  -v, --verbose  increase logging verbosity to debug
  --json         return a JSON string (default)
  --lookml       return a LookML string
  -f, --format   parse and write back to the LookML file
```